### PR TITLE
회원가입 페이지 이동 시 url 문제 해결

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,6 +13,10 @@ export async function middleware(request: NextRequest) {
       );
     }
 
+    if (nextUrl.pathname.startsWith("/signin")) {
+      return NextResponse.next();
+    }
+
     const { pathname, search, origin, basePath } = nextUrl;
     const signInUrl = new URL(`${basePath}/signin`, origin);
     signInUrl.searchParams.append(
@@ -32,5 +36,5 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/", "/product-list", "/search", "/mypage", "/signin"],
+  matcher: ["/", "/product-list", "/search", "/mypage", '/signin'],
 };


### PR DESCRIPTION
- middleware에서 회원가입 페이지를 검사하면서 url이 무한히 반복되는 문제 해결
- 로그인하지 않고 회원가입 페이지 접근 시 middleware에서 조건문으로 정상 동작하게 수정